### PR TITLE
kcptun_for_ss_ssr-install.sh修复1295行的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A tool to auto-compile & install KCPTUN for SS/SSR on Linux
 ------
 ###<a name="Install_command">安装命令
 ```Bash
-    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/onekeyshell/kcptun_for_ss_ssr/patch-1/kcptun_for_ss_ssr-install.sh
+    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/onekeyshell/kcptun_for_ss_ssr/master/kcptun_for_ss_ssr-install.sh
     chmod 700 ./kcptun_for_ss_ssr-install.sh
     ./kcptun_for_ss_ssr-install.sh install
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A tool to auto-compile & install KCPTUN for SS/SSR on Linux
 ------
 ###<a name="Install_command">安装命令
 ```Bash
-    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/onekeyshell/kcptun_for_ss_ssr/master/kcptun_for_ss_ssr-install.sh
+    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/LYJSPEEDX/kcptun_for_ss_ssr/patch-1/kcptun_for_ss_ssr-install.sh
     chmod 700 ./kcptun_for_ss_ssr-install.sh
     ./kcptun_for_ss_ssr-install.sh install
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A tool to auto-compile & install KCPTUN for SS/SSR on Linux
 ------
 ###<a name="Install_command">安装命令
 ```Bash
-    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://github.com/LYJSPEEDX/kcptun_for_ss_ssr.git
+    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/LYJSPEEDX/kcptun_for_ss_ssr/patch-1/kcptun_for_ss_ssr-install.sh
     chmod 700 ./kcptun_for_ss_ssr-install.sh
     ./kcptun_for_ss_ssr-install.sh install
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A tool to auto-compile & install KCPTUN for SS/SSR on Linux
 ------
 ###<a name="Install_command">安装命令
 ```Bash
-    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/onekeyshell/kcptun_for_ss_ssr/master/kcptun_for_ss_ssr-install.sh
+    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://github.com/LYJSPEEDX/kcptun_for_ss_ssr.git
     chmod 700 ./kcptun_for_ss_ssr-install.sh
     ./kcptun_for_ss_ssr-install.sh install
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A tool to auto-compile & install KCPTUN for SS/SSR on Linux
 ------
 ###<a name="Install_command">安装命令
 ```Bash
-    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/LYJSPEEDX/kcptun_for_ss_ssr/patch-1/kcptun_for_ss_ssr-install.sh
+    wget --no-check-certificate -O ./kcptun_for_ss_ssr-install.sh https://raw.githubusercontent.com/onekeyshell/kcptun_for_ss_ssr/patch-1/kcptun_for_ss_ssr-install.sh
     chmod 700 ./kcptun_for_ss_ssr-install.sh
     ./kcptun_for_ss_ssr-install.sh install
 ```

--- a/kcptun_for_ss_ssr-install.sh
+++ b/kcptun_for_ss_ssr-install.sh
@@ -1293,7 +1293,7 @@ pre_install_kcptun_for_ss_ssr(){
                 ;;
             11|[xX][oO][rR])
                 set_kcptun_method="xor"
-                ；；
+                ;;
             12|[Nn][Oo][Nn][Ee])
                 set_kcptun_method="none"
                 ;;

--- a/kcptun_for_ss_ssr-install.sh
+++ b/kcptun_for_ss_ssr-install.sh
@@ -1293,6 +1293,7 @@ pre_install_kcptun_for_ss_ssr(){
                 ;;
             11|[xX][oO][rR])
                 set_kcptun_method="xor"
+                ；；
             12|[Nn][Oo][Nn][Ee])
                 set_kcptun_method="none"
                 ;;


### PR DESCRIPTION
1295行后面没有加两个分号导致安装报错，现修复